### PR TITLE
adding a c type to ros primitive type conversion

### DIFF
--- a/franka_example_controllers/src/force_example_controller.cpp
+++ b/franka_example_controllers/src/force_example_controller.cpp
@@ -12,6 +12,8 @@
 
 #include <franka/robot_state.h>
 #include "pseudo_inversion.h"
+#include "utils.h"
+
 namespace franka_example_controllers {
 
 bool ForceExampleController::init(hardware_interface::RobotHW* robot_hw,
@@ -198,12 +200,12 @@ void ForceExampleController::update(const ros::Time& /*time*/, const ros::Durati
   tau_cmd = tau_d + k_p_ * (tau_d - tau_ext) + k_i_ * tau_error_;
   tau_cmd << saturateTorqueRate(tau_cmd, tau_J_d);
 
-  tau_pub_0.publish(expected_torques(0));
-  tau_pub_1.publish(expected_torques(1));
-  tau_pub_2.publish(expected_torques(2));
-  tau_pub_3.publish(expected_torques(3));
-  tau_pub_4.publish(expected_torques(4));
-  tau_pub_5.publish(expected_torques(5));
+  tau_pub_0.publish(toROSType(expected_torques(0)));
+  tau_pub_1.publish(toROSType(expected_torques(1)));
+  tau_pub_2.publish(toROSType(expected_torques(2)));
+  tau_pub_3.publish(toROSType(expected_torques(3)));
+  tau_pub_4.publish(toROSType(expected_torques(4)));
+  tau_pub_5.publish(toROSType(expected_torques(5)));
   // tau_pub_6.publish(tau_cmd(6));
 
   for (size_t i = 0; i < 7; ++i) {

--- a/franka_example_controllers/src/hiro_joint_velocity_effort_controller.cpp
+++ b/franka_example_controllers/src/hiro_joint_velocity_effort_controller.cpp
@@ -14,6 +14,7 @@
 #include <franka/robot_state.h>
 #include "pseudo_inversion.h"
 #include <ros/ros.h>
+#include "utils.h"
 
 #include <numeric>
 
@@ -213,14 +214,14 @@ void HIROVelocityEffortController::update(const ros::Time& /* time */,
     effort_joint_handles_[i].setCommand(control_command);
     
 
-    pubs[i].publish(control_command);
+    pubs[i].publish(toROSType(control_command));
     // pubs_fake[i].publish(r(i) - (control_command));
   }
   r =  (pinv * (tau_measured - (tau_J_d + gravity))) - wrench;
   for (int i =0; i<7; i++)
   {
     std::cout << r(i) << std::endl;
-    pubs_fake[i].publish(r(i));
+    pubs_fake[i].publish(toROSType(r(i)));
 
   }
   // r = (tau_measured - gravity - coriolis_matrix - (mass_matrix * dq) - tau_ext_initial_);

--- a/franka_example_controllers/src/joint_velocity_example_controller.cpp
+++ b/franka_example_controllers/src/joint_velocity_example_controller.cpp
@@ -8,6 +8,7 @@
 #include "std_msgs/Float64.h"
 #include <franka/robot_state.h>
 #include "pseudo_inversion.h"
+#include "utils.h"
 #include <ros/ros.h>
 #include <numeric>
 
@@ -133,9 +134,9 @@ Eigen::MatrixXd JointVelocityExampleController::getCartesianVelocity(
                                        bool publish_velocity){
   Eigen::MatrixXd x_dot = jacobian * q_dot;
   if(publish_velocity){
-    x_dot_pub.publish(x_dot(0));
-    y_dot_pub.publish(x_dot(1));
-    z_dot_pub.publish(x_dot(2));  
+    x_dot_pub.publish(toROSType(x_dot(0)));
+    y_dot_pub.publish(toROSType(x_dot(1)));
+    z_dot_pub.publish(toROSType(x_dot(2)));
   }
   return x_dot;
 }
@@ -172,9 +173,9 @@ Eigen::Map<Eigen::Matrix<double, 7, 1>> JointVelocityExampleController::updateJo
   Eigen::VectorXd tau_ext = tau_measured - gravity - tau_ext_initial_;
   Eigen::MatrixXd ext_cartesian_wrench = (pinv  * (tau_measured - gravity -  coriolis_matrix - (0.1 * (mass_matrix * ddq)))) - wrench;
   if(publish_values){
-    ext_cart_force_pub_x.publish(ext_cartesian_wrench(0));
-    ext_cart_force_pub_y.publish(ext_cartesian_wrench(1));
-    ext_cart_force_pub_z.publish(ext_cartesian_wrench(2));
+    ext_cart_force_pub_x.publish(toROSType(ext_cartesian_wrench(0)));
+    ext_cart_force_pub_y.publish(toROSType(ext_cartesian_wrench(1)));
+    ext_cart_force_pub_z.publish(toROSType(ext_cartesian_wrench(2)));
   }
   return ext_cartesian_wrench;
 

--- a/franka_example_controllers/src/utils.h
+++ b/franka_example_controllers/src/utils.h
@@ -1,0 +1,18 @@
+/**
+ * @file helper_functions.h
+ *
+ * @brief Helper functions for example controller code.
+ *
+ * @author Nataliya Nechyporenko
+ *
+ */
+
+#pragma once
+
+#include "std_msgs/Float64.h"
+
+inline std_msgs::Float64 toROSType(double value) {
+  std_msgs::Float64 msg;
+  msg.data = value;
+  return msg;
+}

--- a/franka_example_controllers/src/zScore.cpp
+++ b/franka_example_controllers/src/zScore.cpp
@@ -1,5 +1,5 @@
 #include <franka_example_controllers/zScore.h>
-
+#include "utils.h"
 
 // Constructors
 zScore::zScore(ros::NodeHandle & node_handle, std::string topic_prefix){
@@ -77,11 +77,11 @@ void zScore::publishValues(){
 
     if(this->publish_values){
         //Create all topics we will publish values to
-        pub_mean.publish(current_mean);
-        pub_positive_threshold.publish(current_mean + current_stdDev * threshold);
-        pub_negative_threshold.publish(current_mean - current_stdDev * threshold);
-        pub_signal.publish(current_signal);
-        pub_raw_value.publish(current_raw_value);
+        pub_mean.publish(toROSType(current_mean));
+        pub_positive_threshold.publish(toROSType(current_mean + current_stdDev * threshold));
+        pub_negative_threshold.publish(toROSType(current_mean - current_stdDev * threshold));
+        pub_signal.publish(toROSType(current_signal));
+        pub_raw_value.publish(toROSType(current_raw_value));
     }
 }
 


### PR DESCRIPTION
- Addressing build issues caused by invalid implicit conversions from a double to a ros float64 type. 
- Added a toROSType function in a separate header file so it can be used in all the example controller cpp files. 